### PR TITLE
caching for quandl4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
       <artifactId>commons-cli</artifactId>
       <version>1.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.2.2</version>
+    </dependency>
   </dependencies>
   <profiles>
     <!-- apply strict build rules, activated with -Dstrict -->

--- a/src/main/java/com/jimmoores/quandl/DataSetRequest.java
+++ b/src/main/java/com/jimmoores/quandl/DataSetRequest.java
@@ -58,6 +58,23 @@ public final class DataSetRequest {
   }
 
   /**
+   *
+   * @return the quandl code corresponding with the request
+   */
+  public String getQuandlCode()
+  {
+    return _quandlCode;
+  }
+
+  /**
+   *
+   * @return the Frequency that was set
+   */
+  public Frequency getFrequency()
+  {
+    return _frequency;
+  }
+  /**
    * Inner builder class.  Create an instance using of("QUANDL/CODE"), call any other
    * methods you need, and finish by calling build().
    */

--- a/src/main/java/com/jimmoores/quandl/SessionOptions.java
+++ b/src/main/java/com/jimmoores/quandl/SessionOptions.java
@@ -1,8 +1,8 @@
 package com.jimmoores.quandl;
 
+import com.jimmoores.quandl.caching.RetentionPolicy;
 import com.jimmoores.quandl.util.ArgumentChecker;
 import com.jimmoores.quandl.util.DefaultRESTDataProvider;
-import com.jimmoores.quandl.util.QuandlRuntimeException;
 import com.jimmoores.quandl.util.RESTDataProvider;
 
 /**
@@ -12,13 +12,17 @@ public final class SessionOptions {
   private String _authToken;
   private RESTDataProvider _restDataProvider;
   private RetryPolicy _retryPolicy;
-  
+  private String _cacheDir;
+  private RetentionPolicy _defaultRetentionPolicy;
+
   private SessionOptions(final Builder builder) {
     _authToken = builder._authToken;
     _restDataProvider = builder._restDataProvider;
     _retryPolicy = builder._retryPolicy;
+    _cacheDir = builder._cacheDir;
+    _defaultRetentionPolicy = builder._defaultRetentionPolicy;
   }
-  
+
   /**
    * Internal Builder class.
    */
@@ -31,11 +35,13 @@ public final class SessionOptions {
     private String _authToken;
     private RESTDataProvider _restDataProvider = new DefaultRESTDataProvider();
     private RetryPolicy _retryPolicy = RetryPolicy.createSequenceRetryPolicy(new long[] { ONE_SECOND, FIVE_SECONDS, TWENTY_SECONDS, SIXTY_SECONDS });
+    private String _cacheDir;
+    private RetentionPolicy _defaultRetentionPolicy;
 
     private Builder(final String authToken) {
       _authToken = authToken;
     }
-    
+
     /**
      * Specify a specific auth token.
      * @param authToken your auth token
@@ -53,7 +59,7 @@ public final class SessionOptions {
     public static Builder withoutAuthToken() {
       return new Builder(null);
     }
-    
+
     /**
      * Specify a custom RESTDataProvider for the session to use when sending requests, intended for testing purposes.
      * @param restDataProvider a RESTDataProvider for the session
@@ -64,7 +70,7 @@ public final class SessionOptions {
       _restDataProvider = restDataProvider;
       return this;
     }
-    
+
     /**
      * Specify the number of retries to execute before giving up on a request.
      * @param retryPolicy  the policy to follow regarding retries
@@ -75,7 +81,7 @@ public final class SessionOptions {
       _retryPolicy = retryPolicy;
       return this;
     }
-    
+
     /**
      * Specify the length of time to wait before retrying
      */
@@ -86,8 +92,22 @@ public final class SessionOptions {
     public SessionOptions build() {
       return new SessionOptions(this);
     }
+
+    public Builder withCacheDir(String cacheDir_)
+    {
+      ArgumentChecker.notNull(cacheDir_, "cacheDir");
+      _cacheDir = cacheDir_;
+      return this;
+    }
+
+    public Builder withDefaultRetentionPolicy(RetentionPolicy policy_)
+    {
+      ArgumentChecker.notNull(policy_, "defaultRetentionPolicy");
+      _defaultRetentionPolicy = policy_;
+      return this;
+    }
   }
-  
+
   /**
    * Get the Quandl auth token stored in this SessionOptions, or null if none was specified.
    * @return the quandl API auth token String, or null if none was specified
@@ -95,7 +115,7 @@ public final class SessionOptions {
   public String getAuthToken() {
     return _authToken;
   }
-  
+
   /**
    * Get the REST data provider to use when sending API requests to Quandl.
    * @return the REST data provider, not null
@@ -103,7 +123,7 @@ public final class SessionOptions {
   public RESTDataProvider getRESTDataProvider() {
     return _restDataProvider;
   }
-  
+
   /**
    * Get the RetryPolicy to use in determining retry behaviour when calls to Quandl fail.
    * The default is a four stage back-off of 1 second, 5 seconds, 20 seconds and lastly 60 seconds.
@@ -112,4 +132,20 @@ public final class SessionOptions {
   public RetryPolicy getRetryPolicy() {
     return _retryPolicy;
   }
+
+  /**
+   *
+   * @return the directory where quandl4j should place data for caching. Null if not set.
+   */
+  public String getCacheDir()
+  {
+    return _cacheDir;
+  }
+
+  public RetentionPolicy getDefaultRetentionPolicy()
+  {
+    return _defaultRetentionPolicy;
+  }
+
+
 }

--- a/src/main/java/com/jimmoores/quandl/caching/CacheManager.java
+++ b/src/main/java/com/jimmoores/quandl/caching/CacheManager.java
@@ -1,8 +1,141 @@
 package com.jimmoores.quandl.caching;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jimmoores.quandl.TabularResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Calendar;
+import java.util.List;
+
 /**
- * Created by mark on 2-3-15.
+ * CacheManager is responsible for loading and saving of cached quandl data.
+ *
+ * Directories are automatically created.
+ *
+ * It uses gson to serialize and deserialize the data. Just in case we ever have to deal with data of type Calendar,
+ * a GMTDateTypeAdapter is registered on the Gson object. Generic conversion routines between json data and objects are
+ * provided.
  */
 public class CacheManager
 {
+  private static final Gson gson = new GsonBuilder().
+    //registerTypeAdapterFactory(GMTDateTypeAdapter.FACTORY).
+    serializeSpecialFloatingPointValues().serializeNulls().create();
+
+  private static Logger s_logger = LoggerFactory.getLogger(CacheManager.class);
+
+  private static final String _encoding = "UTF-8";
+
+  private String  _baseDir;
+
+  /**
+   *
+   * @param cacheDir_ the directory for storing data
+   * creates a CacheManager that will store the data in the directory 'cacheDir_'.
+   */
+  public CacheManager(String cacheDir_)
+  {
+    if (cacheDir_.endsWith("/"))
+    {
+      _baseDir = cacheDir_;
+    } else
+    {
+      _baseDir = cacheDir_ + "/";
+    }
+  }
+
+  /**
+   *
+   * @param quandlCode_ The quandl code corresponding to the data
+   * @param tabularResponse_ the data that will be saved
+   * @throws FileNotFoundException
+   * @throws UnsupportedEncodingException
+   * Store the data with contents 'tabularResponse_' in a file with name based upon 'quandlCode_'
+   * Note that a quandlCode may contain slashes in its name. This may cause deep subdirectory structures
+   */
+  public void store(String quandlCode_, TabularResult tabularResponse_) throws FileNotFoundException, UnsupportedEncodingException
+  {
+    // the name may contain slashes, we should check if we need to create a new directory
+    File file = new File(_baseDir + quandlCode_);
+    File dir =  file.getParentFile() ;
+    if (!dir.exists())
+    {
+      dir.mkdirs();
+    }
+    String result = convertToJson(tabularResponse_);
+    PrintWriter writer = new PrintWriter(file, _encoding);
+    writer.println(result);
+    writer.close();
+  }
+
+  /** This method deserializes the specified Json into an object of the specified class.
+   *
+   */
+  public static  <T> T convertFromJson(String toConvert,  Class<T>  clazz){
+    return gson.fromJson(toConvert, clazz);
+  }
+
+  /** This method deserializes the specified Json into an object of the specified class.
+   *
+   */
+  public static  <T> T convertFromJson(String toConvert,  Type typeOfT){
+    return gson.fromJson(toConvert, typeOfT);
+  }
+
+  /**
+   * This method serializes the specified object into its equivalent Json representation.
+   */
+  public static String convertToJson(Object toConvert){
+    return gson.toJson(toConvert);
+
+  }
+
+  /**
+   *
+   * @param quandlCode_ The quandl code corresponding to the data
+   * @return the TabularResult for this quandlCode_, null if the data is too old or missing.
+   */
+  public TabularResult load(String quandlCode_, RetentionPolicy policy_)
+  {
+    if (policy_ == null)
+    {
+      return null;
+    }
+    File file = new File(_baseDir + quandlCode_);
+    Path filePath = file.toPath();
+    BasicFileAttributes attributes = null;
+    try
+    {
+      attributes = Files.readAttributes(filePath, BasicFileAttributes.class);
+      Calendar creationTime = Calendar.getInstance();
+      creationTime.setTimeInMillis(attributes.creationTime().toMillis());
+      if (policy_.shouldReload(creationTime))
+      {
+        return null;
+      }
+      List<String> lines = Files.readAllLines(filePath, StandardCharsets.UTF_8);
+      if (lines.size() > 0)
+      {
+        String jsonEncoded = lines.get(0);
+        TabularResult result = convertFromJson(jsonEncoded, TabularResult.class);
+        s_logger.info("Loaded " + quandlCode_ + " from cache");
+        return result;
+      }
+    }
+    catch (IOException exception)
+    {
+      return null;
+    }
+    return null;
+  }
+
 }
+

--- a/src/main/java/com/jimmoores/quandl/caching/CacheManager.java
+++ b/src/main/java/com/jimmoores/quandl/caching/CacheManager.java
@@ -1,0 +1,8 @@
+package com.jimmoores.quandl.caching;
+
+/**
+ * Created by mark on 2-3-15.
+ */
+public class CacheManager
+{
+}

--- a/src/main/java/com/jimmoores/quandl/caching/RetentionPolicy.java
+++ b/src/main/java/com/jimmoores/quandl/caching/RetentionPolicy.java
@@ -1,8 +1,99 @@
 package com.jimmoores.quandl.caching;
 
+import com.jimmoores.quandl.Frequency;
+
+import java.util.Calendar;
+
 /**
- * Created by mark on 2-3-15.
+ * RetentionPolicy describes when we should reload data from quandl, instead of getting it from the cache
  */
-public class RetentionPolicy
+public abstract class RetentionPolicy
 {
+  /**
+   *
+   * @return true if based on this RetentionPolicy the cached data is too old
+   * @param creationTime_ the date and time when the cache file was created as a Calendar object
+   */
+  abstract boolean shouldReload(Calendar creationTime_);
+
+  public static RetentionPolicy create(Frequency frequency_)
+  {
+    if (frequency_ == null)
+    {
+      return null;
+    }
+    switch (frequency_)
+    {
+      case NONE:
+        return Never;
+      case DAILY:
+        return Day;
+      case WEEKLY:
+        return Week;
+      case MONTHLY:
+        return Month;
+      case QUARTERLY:
+        return Month;
+      case ANNUAL:
+        return Year;
+      default:
+        return Never;
+    }
+  }
+
+  public static RetentionPolicy Day = new RetentionPolicy()
+  {
+    @Override
+    public boolean shouldReload(Calendar creationTime_)
+    {
+      Calendar now = Calendar.getInstance();
+      return !((now.get(Calendar.YEAR) == creationTime_.get(Calendar.YEAR))
+        && (now.get(Calendar.MONTH) == creationTime_.get(Calendar.MONTH))
+        && (now.get(Calendar.DAY_OF_MONTH) == creationTime_.get(Calendar.DAY_OF_MONTH)));
+    }
+  };
+
+  public static RetentionPolicy Week = new RetentionPolicy()
+  {
+    @Override
+    public boolean shouldReload(Calendar creationTime_)
+    {
+      Calendar now = Calendar.getInstance();
+      return !((now.get(Calendar.YEAR) == creationTime_.get(Calendar.YEAR))
+        && (now.get(Calendar.WEEK_OF_YEAR) == creationTime_.get(Calendar.WEEK_OF_YEAR))
+      );
+    }
+  };
+
+  public static RetentionPolicy Month = new RetentionPolicy()
+  {
+    @Override
+    public boolean shouldReload(Calendar creationTime_)
+    {
+      Calendar now = Calendar.getInstance();
+      return !((now.get(Calendar.YEAR) == creationTime_.get(Calendar.YEAR))
+        && (now.get(Calendar.MONTH) == creationTime_.get(Calendar.MONTH))
+      );
+    }
+  };
+
+  public static RetentionPolicy Year = new RetentionPolicy()
+  {
+    @Override
+    public boolean shouldReload(Calendar creationTime_)
+    {
+      Calendar now = Calendar.getInstance();
+      return !((now.get(Calendar.YEAR) == creationTime_.get(Calendar.YEAR))
+      );
+    }
+  };
+
+  public static RetentionPolicy Never = new RetentionPolicy()
+  {
+    @Override
+    public boolean shouldReload(Calendar creationTime_)
+    {
+      return true;
+    }
+  };
 }

--- a/src/main/java/com/jimmoores/quandl/caching/RetentionPolicy.java
+++ b/src/main/java/com/jimmoores/quandl/caching/RetentionPolicy.java
@@ -1,0 +1,8 @@
+package com.jimmoores.quandl.caching;
+
+/**
+ * Created by mark on 2-3-15.
+ */
+public class RetentionPolicy
+{
+}

--- a/src/main/java/com/jimmoores/quandl/example/Demo.java
+++ b/src/main/java/com/jimmoores/quandl/example/Demo.java
@@ -16,6 +16,8 @@ import com.jimmoores.quandl.TabularResult;
 import com.jimmoores.quandl.Transform;
 import com.jimmoores.quandl.util.PrettyPrinter;
 
+import java.io.FileNotFoundException;
+
 /**
  * Demo using Quandl library.
  */
@@ -39,20 +41,27 @@ public final class Demo {
     for (MetaDataResult metaData : searchResult.getMetaDataResultList()) {
       System.out.println(PrettyPrinter.toPrettyPrintedString(metaData.getRawJSON()));
     }
-    TabularResult tabularResult = quandl.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL").withFrequency(Frequency.QUARTERLY)
-                                                                          .withColumn(CLOSE_COLUMN).withTransform(Transform.NORMALIZE).build());
-    System.out.println(PrettyPrinter.toPrettyPrintedString(tabularResult));
-    TabularResult tabularResultMulti = quandl.getDataSets(
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = quandl.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL").withFrequency(Frequency.QUARTERLY)
+                                                                            .withColumn(CLOSE_COLUMN).withTransform(Transform.NORMALIZE).build());
+      System.out.println(PrettyPrinter.toPrettyPrintedString(tabularResult));
+      TabularResult tabularResultMulti = quandl.getDataSets(
                                          MultiDataSetRequest.Builder.of(
                                            QuandlCodeRequest.allColumns("WIKI/AAPL"), 
                                            QuandlCodeRequest.allColumns("DOE/RWTC")
                                          ).withStartDate(RECENTISH_DATE)
                                          .build());
-    System.out.println(PrettyPrinter.toPrettyPrintedString(tabularResultMulti));    
-    MetaDataResult metaData = quandl.getMetaData(MetaDataRequest.of("WIKI/AAPL"));
-    System.out.println(PrettyPrinter.toPrettyPrintedString(metaData.getRawJSON()));
-    MetaDataResult metaData2 = quandl.getMetaData(MultiMetaDataRequest.of("WIKI/AAPL", "DOE/RWTC", "WIKI/MSFT"));
-    System.out.println(PrettyPrinter.toPrettyPrintedString(metaData2.getRawJSON()));
+      System.out.println(PrettyPrinter.toPrettyPrintedString(tabularResultMulti));
+      MetaDataResult metaData = quandl.getMetaData(MetaDataRequest.of("WIKI/AAPL"));
+      System.out.println(PrettyPrinter.toPrettyPrintedString(metaData.getRawJSON()));
+      MetaDataResult metaData2 = quandl.getMetaData(MultiMetaDataRequest.of("WIKI/AAPL", "DOE/RWTC", "WIKI/MSFT"));
+      System.out.println(PrettyPrinter.toPrettyPrintedString(metaData2.getRawJSON()));
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
 
   /**

--- a/src/main/java/com/jimmoores/quandl/example/Example1.java
+++ b/src/main/java/com/jimmoores/quandl/example/Example1.java
@@ -4,6 +4,8 @@ import com.jimmoores.quandl.DataSetRequest;
 import com.jimmoores.quandl.QuandlSession;
 import com.jimmoores.quandl.TabularResult;
 
+import java.io.FileNotFoundException;
+
 /**
  * Example 1.
  */
@@ -19,9 +21,16 @@ public final class Example1 {
    */
   private void run() {
     QuandlSession session = QuandlSession.create();
-    TabularResult tabularResult = session.getDataSet(
-      DataSetRequest.Builder.of("WIKI/AAPL").build());
-    System.out.println(tabularResult.toPrettyPrintedString());
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(
+        DataSetRequest.Builder.of("WIKI/AAPL").build());
+      System.out.println(tabularResult.toPrettyPrintedString());
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
 
   /**

--- a/src/main/java/com/jimmoores/quandl/example/Example2.java
+++ b/src/main/java/com/jimmoores/quandl/example/Example2.java
@@ -6,6 +6,8 @@ import com.jimmoores.quandl.QuandlSession;
 import com.jimmoores.quandl.TabularResult;
 import com.jimmoores.quandl.Transform;
 
+import java.io.FileNotFoundException;
+
 /**
  * Example 2.
  */
@@ -23,13 +25,20 @@ public final class Example2 {
    */
   private void run() {
     QuandlSession session = QuandlSession.create();
-    TabularResult tabularResult = session.getDataSet(
-      DataSetRequest.Builder
-        .of("WIKI/AAPL")
-        .withFrequency(Frequency.QUARTERLY)
-        .withColumn(CLOSE_COLUMN)
-        .withTransform(Transform.NORMALIZE)
-        .build());
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(
+        DataSetRequest.Builder
+          .of("WIKI/AAPL")
+          .withFrequency(Frequency.QUARTERLY)
+          .withColumn(CLOSE_COLUMN)
+          .withTransform(Transform.NORMALIZE)
+          .build());
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
     System.out.println(tabularResult.toPrettyPrintedString());  }
 
   /**

--- a/src/main/java/com/jimmoores/quandl/example/Example3.java
+++ b/src/main/java/com/jimmoores/quandl/example/Example3.java
@@ -8,6 +8,8 @@ import com.jimmoores.quandl.QuandlCodeRequest;
 import com.jimmoores.quandl.QuandlSession;
 import com.jimmoores.quandl.TabularResult;
 
+import java.io.FileNotFoundException;
+
 /**
  * Example 3.
  */
@@ -26,16 +28,23 @@ public final class Example3 {
    */
   private void run() {
     QuandlSession session = QuandlSession.create();
-    TabularResult tabularResultMulti = session.getDataSets(
-        MultiDataSetRequest.Builder
-          .of(
-            QuandlCodeRequest.singleColumn("WIKI/AAPL", CLOSE_COLUMN), 
-            QuandlCodeRequest.allColumns("DOE/RWTC")
-          )
-          .withStartDate(RECENTISH_DATE)
-          .withFrequency(Frequency.MONTHLY)
-          .build());
-    System.out.println(tabularResultMulti.toPrettyPrintedString());  
+    TabularResult tabularResultMulti = null;
+    try
+    {
+      tabularResultMulti = session.getDataSets(
+          MultiDataSetRequest.Builder
+            .of(
+              QuandlCodeRequest.singleColumn("WIKI/AAPL", CLOSE_COLUMN),
+              QuandlCodeRequest.allColumns("DOE/RWTC")
+            )
+            .withStartDate(RECENTISH_DATE)
+            .withFrequency(Frequency.MONTHLY)
+            .build());
+      System.out.println(tabularResultMulti.toPrettyPrintedString());
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
 
   /**

--- a/src/main/java/com/jimmoores/quandl/example/Example3a.java
+++ b/src/main/java/com/jimmoores/quandl/example/Example3a.java
@@ -1,5 +1,6 @@
 package com.jimmoores.quandl.example;
 
+import java.io.FileNotFoundException;
 import java.util.Iterator;
 
 import org.threeten.bp.LocalDate;
@@ -29,23 +30,30 @@ public final class Example3a {
    */
   private void run() {
     QuandlSession session = QuandlSession.create();
-    TabularResult tabularResultMulti = session.getDataSets(
-        MultiDataSetRequest.Builder
-          .of(
-            QuandlCodeRequest.singleColumn("WIKI/AAPL", CLOSE_COLUMN), 
-            QuandlCodeRequest.allColumns("DOE/RWTC")
-          )
-          .withStartDate(RECENTISH_DATE)
-          .withFrequency(Frequency.MONTHLY)
-          .build());
-    System.out.println("Header definition: " + tabularResultMulti.getHeaderDefinition());
-    Iterator<Row> iter = tabularResultMulti.iterator();
-    while (iter.hasNext()) {
-      Row row = iter.next();
-      LocalDate date = row.getLocalDate("Date");
-      Double value = row.getDouble("DOE/RWTC - Value");
-      System.out.println("Value on date " + date + " was " + value);
-    } 
+    TabularResult tabularResultMulti = null;
+    try
+    {
+      tabularResultMulti = session.getDataSets(
+          MultiDataSetRequest.Builder
+            .of(
+              QuandlCodeRequest.singleColumn("WIKI/AAPL", CLOSE_COLUMN),
+              QuandlCodeRequest.allColumns("DOE/RWTC")
+            )
+            .withStartDate(RECENTISH_DATE)
+            .withFrequency(Frequency.MONTHLY)
+            .build());
+      System.out.println("Header definition: " + tabularResultMulti.getHeaderDefinition());
+      Iterator<Row> iter = tabularResultMulti.iterator();
+      while (iter.hasNext()) {
+        Row row = iter.next();
+        LocalDate date = row.getLocalDate("Date");
+        Double value = row.getDouble("DOE/RWTC - Value");
+        System.out.println("Value on date " + date + " was " + value);
+      }
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
 
   /**

--- a/src/main/java/com/jimmoores/quandl/example/Example9.java
+++ b/src/main/java/com/jimmoores/quandl/example/Example9.java
@@ -1,12 +1,13 @@
-package main.java.com.jimmoores.quandl.example;
+package com.jimmoores.quandl.example;
 
-import com.jimmoores.quandl.MetaDataResult;
-import com.jimmoores.quandl.QuandlSession;
-import com.jimmoores.quandl.SearchRequest;
-import com.jimmoores.quandl.SearchResult;
+import com.jimmoores.quandl.*;
+import com.jimmoores.quandl.caching.RetentionPolicy;
+
+import java.io.FileNotFoundException;
 
 /**
  * Example 8.
+ * Demonstrates caching
  */
 public final class Example9
 {
@@ -21,14 +22,20 @@ public final class Example9
    * The main body of the code.
    */
   private void run() {
-    QuandlSession session = QuandlSession.create();
-    SearchResult searchResult = session.search(SearchRequest.Builder.of("Apple").withMaxPerPage(2).build());
-    System.out.println("Current page:" + searchResult.getCurrentPage());
-    System.out.println("Documents per page:" + searchResult.getDocumentsPerPage());
-    System.out.println("Total matching documents:" + searchResult.getTotalDocuments());
-    for (MetaDataResult document : searchResult.getMetaDataResultList()) {
-      System.out.println("Quandl code " + document.getQuandlCode() + " matched");
-      System.out.println("Available columns are: " + document.getHeaderDefinition());
+    SessionOptions sessionOptions = SessionOptions.Builder.withoutAuthToken()
+      .withCacheDir(".")
+      .withDefaultRetentionPolicy(RetentionPolicy.Day)
+      .build();
+    QuandlSession session = QuandlSession.create(sessionOptions);
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(
+        DataSetRequest.Builder.of("WIKI/AAPL").build());
+      System.out.println(tabularResult.toPrettyPrintedString());
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
     }
   }
 
@@ -37,7 +44,7 @@ public final class Example9
    * @param args command line arguments
    */
   public static void main(final String[] args) {
-    com.jimmoores.quandl.example.Example8 example = new com.jimmoores.quandl.example.Example8();
+    Example9 example = new Example9();
     example.run();
   }
 }

--- a/src/main/java/com/jimmoores/quandl/example/Example9.java
+++ b/src/main/java/com/jimmoores/quandl/example/Example9.java
@@ -1,0 +1,43 @@
+package main.java.com.jimmoores.quandl.example;
+
+import com.jimmoores.quandl.MetaDataResult;
+import com.jimmoores.quandl.QuandlSession;
+import com.jimmoores.quandl.SearchRequest;
+import com.jimmoores.quandl.SearchResult;
+
+/**
+ * Example 8.
+ */
+public final class Example9
+{
+
+  /**
+   * Private default constructor.
+   */
+  private Example9() {
+  }
+ 
+  /**
+   * The main body of the code.
+   */
+  private void run() {
+    QuandlSession session = QuandlSession.create();
+    SearchResult searchResult = session.search(SearchRequest.Builder.of("Apple").withMaxPerPage(2).build());
+    System.out.println("Current page:" + searchResult.getCurrentPage());
+    System.out.println("Documents per page:" + searchResult.getDocumentsPerPage());
+    System.out.println("Total matching documents:" + searchResult.getTotalDocuments());
+    for (MetaDataResult document : searchResult.getMetaDataResultList()) {
+      System.out.println("Quandl code " + document.getQuandlCode() + " matched");
+      System.out.println("Available columns are: " + document.getHeaderDefinition());
+    }
+  }
+
+  /**
+   * Main entry point.
+   * @param args command line arguments
+   */
+  public static void main(final String[] args) {
+    com.jimmoores.quandl.example.Example8 example = new com.jimmoores.quandl.example.Example8();
+    example.run();
+  }
+}

--- a/src/test/java/com/jimmoores/quandl/tests/RegressionTests.java
+++ b/src/test/java/com/jimmoores/quandl/tests/RegressionTests.java
@@ -1,5 +1,6 @@
 package com.jimmoores.quandl.tests;
 
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -183,6 +184,10 @@ public final class RegressionTests {
       } catch (QuandlRuntimeException qre) {
         s_logger.warn("Caught" + qre);
         s_logger.info("Continuing...");
+      } catch (FileNotFoundException e)
+      {
+        s_logger.warn("Caught" + e);
+        s_logger.info("Continuing...");
       }
     }
   }
@@ -237,6 +242,10 @@ public final class RegressionTests {
         s_logger.info(PrettyPrinter.toPrettyPrintedString(dataSet));
       } catch (QuandlRuntimeException qre) {
         s_logger.warn("Caught exception", qre);
+        s_logger.info("Continuing...");
+      } catch (FileNotFoundException e)
+      {
+        s_logger.warn("Caught exception", e);
         s_logger.info("Continuing...");
       }
     }

--- a/src/test/java/com/jimmoores/quandl/tests/URLGenerationTests.java
+++ b/src/test/java/com/jimmoores/quandl/tests/URLGenerationTests.java
@@ -1,5 +1,6 @@
 package com.jimmoores.quandl.tests;
 
+import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.Collections;
 
@@ -17,13 +18,11 @@ import com.jimmoores.quandl.MetaDataRequest;
 import com.jimmoores.quandl.MetaDataResult;
 import com.jimmoores.quandl.MultiDataSetRequest;
 import com.jimmoores.quandl.MultiMetaDataRequest;
-import com.jimmoores.quandl.QuandlCodeRequest;
 import com.jimmoores.quandl.QuandlSession;
 import com.jimmoores.quandl.Row;
 import com.jimmoores.quandl.SearchRequest;
 import com.jimmoores.quandl.SearchResult;
 import com.jimmoores.quandl.SessionOptions;
-import com.jimmoores.quandl.SortOrder;
 import com.jimmoores.quandl.TabularResult;
 import com.jimmoores.quandl.Transform;
 import com.jimmoores.quandl.util.QuandlRuntimeException;
@@ -61,7 +60,7 @@ public class URLGenerationTests {
       Assert.assertEquals(_expectedURL, uri.toString());
       return TEST_TABULAR_RESULT;
     }
-  };
+  }
   
   private QuandlSession getTestSession(final String expectedURL) {
     return QuandlSession.create(
@@ -74,59 +73,94 @@ public class URLGenerationTests {
   @Test
   public void testSimpleGetDataSet() {
     QuandlSession session = getTestSession("http://quandl.com/api/v1/datasets/WIKI/MSFT.csv");
-    TabularResult tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/MSFT").build());
-    Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/MSFT").build());
+      Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
   
   @Test
   public void testMoreComplexGetDataSet() {
     QuandlSession session = getTestSession("http://quandl.com/api/v1/datasets/WIKI/AAPL.csv?column=4&collapse=quarterly&transformation=normalize");
-    TabularResult tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL")
-                                                                           .withFrequency(Frequency.QUARTERLY)
-                                                                           .withColumn(CLOSE_COLUMN)
-                                                                           .withTransform(Transform.NORMALIZE)
-                                                                           .build());
-    Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL")
+                                                                             .withFrequency(Frequency.QUARTERLY)
+                                                                             .withColumn(CLOSE_COLUMN)
+                                                                             .withTransform(Transform.NORMALIZE)
+                                                                             .build());
+      Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
   
   @Test
   public void testMostComplexGetDataSet() {
     QuandlSession session = getTestSession("http://quandl.com/api/v1/datasets/WIKI/AAPL.csv?trim_start=2009-01-01&trim_end=2010-12-31&column=4&collapse=quarterly&rows=10&transformation=normalize");
-    TabularResult tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL")
-                                                                           .withStartDate(LocalDate.of(2009, 1, 1))
-                                                                           .withEndDate(LocalDate.of(2010, 12, 31))
-                                                                           .withMaxRows(10)
-                                                                           .withFrequency(Frequency.QUARTERLY)
-                                                                           .withColumn(CLOSE_COLUMN)
-                                                                           .withTransform(Transform.NORMALIZE)
-                                                                           .build());
-    Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL")
+                                                                             .withStartDate(LocalDate.of(2009, 1, 1))
+                                                                             .withEndDate(LocalDate.of(2010, 12, 31))
+                                                                             .withMaxRows(10)
+                                                                             .withFrequency(Frequency.QUARTERLY)
+                                                                             .withColumn(CLOSE_COLUMN)
+                                                                             .withTransform(Transform.NORMALIZE)
+                                                                             .build());
+      Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
   
   @Test
   public void testMostComplexGetDataSetDifferentOrder() {
     // now try a different order
     QuandlSession session = getTestSession("http://quandl.com/api/v1/datasets/WIKI/AAPL.csv?trim_start=2009-01-01&trim_end=2010-12-31&column=4&collapse=quarterly&rows=10&transformation=normalize");
-    TabularResult tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL")
-                                                                            .withFrequency(Frequency.QUARTERLY)
-                                                                            .withColumn(CLOSE_COLUMN)
-                                                                            .withStartDate(LocalDate.of(2009, 1, 1))
-                                                                            .withEndDate(LocalDate.of(2010, 12, 31))
-                                                                            .withMaxRows(10)
-                                                                            .withTransform(Transform.NORMALIZE)
-                                                                            .build());
-    Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSet(DataSetRequest.Builder.of("WIKI/AAPL")
+                                                                              .withFrequency(Frequency.QUARTERLY)
+                                                                              .withColumn(CLOSE_COLUMN)
+                                                                              .withStartDate(LocalDate.of(2009, 1, 1))
+                                                                              .withEndDate(LocalDate.of(2010, 12, 31))
+                                                                              .withMaxRows(10)
+                                                                              .withTransform(Transform.NORMALIZE)
+                                                                              .build());
+      Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
   
   @Test(expectedExceptions = QuandlRuntimeException.class)
   public void testLargeMultiDataSetRequestWithEmpty() {
     QuandlSession session = getTestSession("http://quandl.com/api/v1/multisets.csv?columns=&collapse=monthly&transformation=normalize");
-    TabularResult tabularResult = session.getDataSets( // expect an exception here because list is empty
-        MultiDataSetRequest.Builder.of()
-        .withFrequency(Frequency.MONTHLY)
-        .withTransform(Transform.NORMALIZE)
-        .build());
-    Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    TabularResult tabularResult = null;
+    try
+    {
+      tabularResult = session.getDataSets( // expect an exception here because list is empty
+          MultiDataSetRequest.Builder.of()
+          .withFrequency(Frequency.MONTHLY)
+          .withTransform(Transform.NORMALIZE)
+          .build());
+      Assert.assertEquals(TEST_TABULAR_RESULT, tabularResult);
+    } catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
   }
   
   // test getMetaData


### PR DESCRIPTION
This should add caching to quandl4j. Example9 shows how.

Unfortunately, some FileNotFoundExceptions have to propagate all the way up to the application level, and this requires a code changes in several files.

The basic idea is pretty simple: the user can pass a place where cache files should reside when creating a QuandlSession. The directory doesn't have to exist. Furthermore, there's the notion of a RetentionPolicy, this determines when data is freshly loaded from quandl, or from the cache. On the QuandlSession a default retention policy can be set, or this can be done per data request by means of setting the Frequency explicitly.

I've added google gson as a dependency. Perhaps the opengamma library can accomplish the same thing, but I'm not familiar with it. Sorry for that.

let me know if there are problems, remarks etc.

regards,

Mark Smeets.