### PR TITLE
HTTPS migration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ List of Contributors
 | Elaine McLeod    | emcleod     | Bug fixes, doc fixes |
 | Mark Smeets      | marksmeets  | File based caching   |
 | Armen Arzumanyan | armdev      | JSF2.2 web app with quandl ehcache at https://github.com/armdev/quandl4j-web-master |
+| Brian Risk       | brianrisk   | HTTPS migration     |

--- a/src/main/java/com/jimmoores/quandl/QuandlSession.java
+++ b/src/main/java/com/jimmoores/quandl/QuandlSession.java
@@ -64,7 +64,7 @@ public final class QuandlSession {
   private static Logger s_logger = LoggerFactory.getLogger(QuandlSession.class);
   
   private SessionOptions _sessionOptions;
-  private static final UriBuilder API_BASE_URL = UriBuilder.fromPath("http://quandl.com/api/v1");
+  private static final UriBuilder API_BASE_URL = UriBuilder.fromPath("https://quandl.com/api/v1");
   private static final String QUANDL_AUTH_TOKEN_PROPERTY_NAME = "quandl.auth.token";
   /**
    * the parameter name for the authorization token (aka Quandl API key).


### PR DESCRIPTION
The Quandl API will soon only accept https calls.  Made a minor code change to reflect that.