### PR TITLE
Consider making TabularResult implement Iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Quandl4J uses [Travis CI](http://travis-ci.org/jimmoores/quandl4j) to perform co
  - [Tutorial](#tutorial)
  - [Documentation](#documentation)
  - [Roadmap](#roadmap)
- - [Contributing](#contributing)
+ - [Contributions](#contributions)
  - [Community](#community)
  - [Versioning](#versioning)
- - [Bugs and feature requests](#bugs-and-feature-requests)
  - [Creator](#creator)
  - [Copyright and license](#copyright-and-license)
 
@@ -231,9 +230,7 @@ TabularResult tabularResultMulti = session.getDataSets(
       .withFrequency(Frequency.MONTHLY)
       .build());
 System.out.println("Header definition: " + tabularResultMulti.getHeaderDefinition());
-Iterator<Row> iter = tabularResultMulti.iterator();
-while (iter.hasNext()) {
-  Row row = iter.next();
+for (final Row row : tabularResultMulti) {
   LocalDate date = row.getLocalDate("Date");
   Double value = row.getDouble("DOE/RWTC - Value");
   System.out.println("Value on date " + date + " was " + value);
@@ -524,7 +521,7 @@ Some future plans for incorporation include:
  - Ability to specify column names in requests that will use cached metadata where possible or fall back to 
    performing a metadata request prior to a data request.
 
-### Contrubutions
+### Contributions
 Contributions are welcome!  Please read through the [contributing guidelines](http://github.com/jimmoores/quandl4j/blob/master/CONTRIBUTING.md).  This gives guidelines on opening issues, coding standards and testing requirements.
 
 ### Community

--- a/src/main/java/com/jimmoores/quandl/TabularResult.java
+++ b/src/main/java/com/jimmoores/quandl/TabularResult.java
@@ -10,7 +10,9 @@ import com.jimmoores.quandl.util.PrettyPrinter;
 /**
  * Represents a result in tabular form.
  */
-public final class TabularResult {
+public final class TabularResult
+implements Iterable<Row> 
+{
   /** definition of each column. */
   private HeaderDefinition _headerDefinition;
   /** list of rows. */

--- a/src/main/java/com/jimmoores/quandl/util/PrettyPrinter.java
+++ b/src/main/java/com/jimmoores/quandl/util/PrettyPrinter.java
@@ -106,9 +106,9 @@ public final class PrettyPrinter {
     separator(sb, maxWidths);
     header(sb, maxWidths, result.getHeaderDefinition());
     separator(sb, maxWidths);
-    Iterator<Row> iter = result.iterator();
-    while (iter.hasNext()) {
-      row(sb, maxWidths, iter.next());
+    for (final Row row : result)
+    {
+      row(sb, maxWidths, row);
     }
     separator(sb, maxWidths);
     return sb.toString();


### PR DESCRIPTION
De facto, an implementation is provided for `Iterable<Row>`. However, this is not declared for the class. Please consider merging the pull request so that the corresponding syntactic sugar is available for library users.