### PR TITLE
Update DefaultRESTDataProvider.java

### DIFF
--- a/src/main/java/com/jimmoores/quandl/util/DefaultRESTDataProvider.java
+++ b/src/main/java/com/jimmoores/quandl/util/DefaultRESTDataProvider.java
@@ -69,7 +69,7 @@ public final class DefaultRESTDataProvider implements RESTDataProvider {
     String value = response.getHeaderString(field);
     if (value != null) {
       try {
-        return Long.parseLong(value);
+        return Long.valueOf(value);
       } catch (NumberFormatException nfe) {
       }
     }


### PR DESCRIPTION
parseOf() return a primitive. Since method parseOptionalHeader() return a boxed Long, prefer valueOf() to avoid unnecessary boxing.