### PR TITLE
Upgrade dependencies. Remove logback from classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,27 +260,26 @@
       </plugins>
     </pluginManagement>
   </build>
-  <dependencies>
+  <dependencies>    
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
-      <version>0.9</version>
-    </dependency>  
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>6.8.8</version>
-      <scope>provided</scope>
+      <version>1.3.6</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.8</version>
+      <version>2.25.1</version>
       <!--scope>provided</scope-->
     </dependency>
     <dependency>
@@ -289,19 +288,26 @@
       <version>2.3</version>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-json-org</artifactId>
       <version>2.8.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.8.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <profiles>


### PR DESCRIPTION
I did not upgrade testng because the newest version requires Java 8 and I wasn't sure if you wanted to drop Java 7 support

It's great that this library uses slf4j for logging. The benefit of using slf4j is that the logging implementation becomes pluggable. Thus, we don't want to include logback on the main runtime classpath so that users can use whatever implementation they choose. I've moved logback to the test scope so that quandl4j uses it for its own tests, but users can use any alternative they choose.